### PR TITLE
corrected hyperlink formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A collection of [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 
 ## Self Publishing
 
-- [https://medium.com/@davetron5000/self-vs-professional-publishing-c3397bd7defd#.lrfhasuo5](Self vs Professional Publishing) - The pros and cons of each, plus a look at many of the options available for self publishing.
+- [Self vs Professional Publishing](https://medium.com/@davetron5000/self-vs-professional-publishing-c3397bd7defd#.lrfhasuo5) - The pros and cons of each, plus a look at many of the options available for self publishing.
 
 ## Writing Workflows and Tooling
 


### PR DESCRIPTION
The hyperlink and text/title were reversed, causing it to break.
![image](https://cloud.githubusercontent.com/assets/622118/14995530/d96b6590-113a-11e6-8c04-aa147616dd7b.png)
